### PR TITLE
fix: don't remove css when press on esc key

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -62,11 +62,18 @@ export default class Prozen extends Plugin {
 				viewEl.classList.add("noscroll")
 			}
 			this.settings.showHeader ? header.classList.add("animate") : header.classList.add("hide")
-
+			return;
 		} else {
 			document.exitFullscreen();
 			viewEl.classList.remove("vignette", "animate", "noscroll")
 			header.classList.remove("animate", "hide")
+		}
+
+		containerEl.onfullscreenchange = () => {
+			if (!document.fullscreenElement && viewEl.classList.contains("vignette")){
+				viewEl.classList.remove("vignette", "animate", "noscroll");
+				header.classList.remove("animate", "hide");
+			}
 		}
 	}
 }

--- a/main.ts
+++ b/main.ts
@@ -64,7 +64,6 @@ export default class Prozen extends Plugin {
 			viewEl.classList.add("animate")
 			leaf.view.getViewType() === "graph" ? viewEl.classList.add("vignette-radial") : viewEl.classList.add("vignette")
 			this.settings.showHeader ? header.classList.add("animate") : header.classList.add("hide")
-			return;
 		} else {
 			document.exitFullscreen();
 
@@ -74,7 +73,7 @@ export default class Prozen extends Plugin {
 
 		containerEl.onfullscreenchange = () => {
 			if (!document.fullscreenElement && viewEl.classList.contains("vignette")){
-				viewEl.classList.remove("vignette", "animate", "noscroll");
+				viewEl.classList.remove("vignette", "vignette-radial", "animate", "noscroll");
 				header.classList.remove("animate", "hide");
 			}
 		}


### PR DESCRIPTION
@cmoskvitin This should fix css wasn't removed when we leave fullscreen mode by pressing ESC key. 